### PR TITLE
Multi Target Uname Spoof for apps 

### DIFF
--- a/arch/arm64/configs/gki_defconfig
+++ b/arch/arm64/configs/gki_defconfig
@@ -750,3 +750,11 @@ CONFIG_SANDEVISTAN_BOOT=y
 CONFIG_YAMADA_GAMING_BOOST=y
 CONFIG_YAMADA_TENEBRION=y
 CONFIG_YAMADA_ANYA_THERMAL=y
+
+###########################
+# Spoof Uname
+###########################
+
+CONFIG_UNAME_OVERRIDE=y
+CONFIG_UNAME_OVERRIDE_TARGET="com.google.android.gms,com.alfamart.alfagift,com.android.vending"
+CONFIG_UNAME_OVERRIDE_STRING="5.10.198-android12-9-00019-g6efebf1322d6-ab11471183"

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -198,6 +198,22 @@ config LOCALVERSION_AUTO
 
 	  which is done within the script "scripts/setlocalversion".)
 
+menuconfig UNAME_OVERRIDE
+	bool "Override uname output for specific processes"
+	help
+	  This will modify struct new_utsname->release string's return value
+	  to another string on a specified process.
+
+if UNAME_OVERRIDE
+
+config UNAME_OVERRIDE_TARGET
+	string "Target process' cmdline for uname override"
+
+config UNAME_OVERRIDE_STRING
+	string "New uname's release string for uname override"
+
+endif
+
 config BUILD_SALT
 	string "Build ID Salt"
 	default ""

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1244,16 +1244,42 @@ static void override_custom_release(char __user *release, size_t len)
 {
 #ifdef CONFIG_UNAME_OVERRIDE
 	char *buf;
+	char *targets_copy, *target, *orig_targets;
+	bool match = false;
 
+	/* Get the name of the app asking for the kernel version */
 	buf = kstrdup_quotable_cmdline(current, GFP_KERNEL);
 	if (buf == NULL)
 		return;
 
-	if (strstr(buf, CONFIG_UNAME_OVERRIDE_TARGET)) {
+	/* Create a copy of our target list because strsep will modify it during parsing */
+	orig_targets = targets_copy = kstrdup(CONFIG_UNAME_OVERRIDE_TARGET, GFP_KERNEL);
+	if (orig_targets == NULL) {
+		kfree(buf);
+		return;
+	}
+
+	/* Split the list by commas and check each target */
+	while ((target = strsep(&targets_copy, ",")) != NULL) {
+		/* Skip empty strings if there are trailing commas */
+		if (*target == '\0')
+			continue;
+			
+		/* If the current app matches one of our targets, flag it! */
+		if (strstr(buf, target)) {
+			match = true;
+			break;
+		}
+	}
+
+	/* If a match was found, deploy the fake ID! */
+	if (match) {
 		copy_to_user(release, CONFIG_UNAME_OVERRIDE_STRING,
 			       strlen(CONFIG_UNAME_OVERRIDE_STRING) + 1);
 	}
 
+	/* Clean up our tracks (free memory) so we don't cause a memory leak/kernel panic */
+	kfree(orig_targets);
 	kfree(buf);
 #endif
 }


### PR DESCRIPTION
Originally is this

https://github.com/arter97/android_kernel_nothing_sm8475/commit/8861034724c6

Then I modify it for it to accept auto target 

SO?! FK YOU ALFAGIFT (com.alfamart.alfagift) YOU FCKIN IMPLEMENT UNAME CHECK?! 
What are you? Even BCA doesn't do that!