### PR TITLE
Yamada Gaming Boost: Fix struct sugov_policy, read more in desc

### DIFF
--- a/drivers/cpufreq/yamada_gaming_boost.c
+++ b/drivers/cpufreq/yamada_gaming_boost.c
@@ -11,6 +11,8 @@
 #include <linux/slab.h>
 #include <linux/mutex.h>
 #include <linux/pm_qos.h>
+#include <linux/ktime.h>
+#include <linux/spinlock.h>
 
 #define BOOST_DURATION_MS   500
 
@@ -24,16 +26,27 @@ MODULE_PARM_DESC(boost_duration_ms, "Boost duration in ms after last input (defa
 
 /* ------------------------------------------------------------------ */
 /* Copied from kernel/sched/cpufreq_schedutil.c — not exported         */
+/*                                                                      */
+/* WARNING: must stay in sync with the compiled kernel's layout.       */
+/* A field inserted before rate_limit_us or tunables in the upstream   */
+/* structs will cause silent memory corruption at runtime.             */
+/* Verified against android12-5.10 cpufreq_schedutil.c                */
 /* ------------------------------------------------------------------ */
 
 struct sugov_tunables {
-    struct gov_attr_set     attr_set;
+    struct gov_attr_set     attr_set;       /* MUST remain first member */
     unsigned int            rate_limit_us;
 };
 
 struct sugov_policy {
-    struct cpufreq_policy   *policy;
+    struct cpufreq_policy   *policy;        /* MUST remain first member */
     struct sugov_tunables   *tunables;
+    struct list_head         tunables_hook;
+
+    raw_spinlock_t           update_lock;
+    u64                      last_freq_update_time;
+    s64                      freq_update_delay_ns;  /* derived: rate_limit_us * NSEC_PER_USEC */
+    /* remaining fields intentionally omitted */
 };
 
 /* ------------------------------------------------------------------ */
@@ -41,10 +54,21 @@ struct sugov_policy {
 /* ------------------------------------------------------------------ */
 
 static bool boost_active = false;
-static DEFINE_MUTEX(boost_lock);
+
+/*
+ * Use a spinlock, not a mutex.  yamada_input_event() is called from
+ * the input core which can run in softirq context on some drivers.
+ * Mutexes may sleep; spinlocks are safe in all contexts.
+ */
+static DEFINE_SPINLOCK(boost_lock);
 static struct delayed_work boost_off_work;
 static struct input_handler yamada_input_handler;
 
+/*
+ * Save rate_limit_us per policy-CPU (the first CPU of each cpufreq
+ * policy cluster).  Indexed by policy->cpu, not by every sibling CPU,
+ * to avoid restoring a stale zero on hotplug.
+ */
 static unsigned int saved_rate_limit_us[NR_CPUS];
 
 /* QoS requests per policy CPU */
@@ -64,10 +88,13 @@ static void set_schedutil_rate_limit(struct cpufreq_policy *policy,
         return;
 
     sg_policy->tunables->rate_limit_us = rate_limit_us;
+    WRITE_ONCE(sg_policy->freq_update_delay_ns,
+               (s64)rate_limit_us * NSEC_PER_USEC);
 }
 
 /* ------------------------------------------------------------------ */
-/* Boost ON                                                             */
+/* Boost ON — called from workqueue (process context), never from      */
+/* the input event directly.  Safe to call sleepable APIs here.        */
 /* ------------------------------------------------------------------ */
 
 static void do_boost_on(void)
@@ -83,7 +110,11 @@ static void do_boost_on(void)
         if (policy->cpu == cpu) {
             struct sugov_policy *sg_policy = policy->governor_data;
 
-            /* Save schedutil rate_limit_us */
+            /*
+             * Save rate_limit_us keyed by the policy's representative
+             * CPU so we never accidentally restore a cold-boot zero
+             * caused by a sibling CPU that was offline at save time.
+             */
             if (sg_policy && sg_policy->tunables)
                 saved_rate_limit_us[cpu] = sg_policy->tunables->rate_limit_us;
 
@@ -108,16 +139,17 @@ static void do_boost_on(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Boost OFF                                                            */
+/* Boost OFF — runs from system_wq (process context), safe to sleep.  */
 /* ------------------------------------------------------------------ */
 
 static void do_boost_off(struct work_struct *work)
 {
     unsigned int cpu;
+    unsigned long flags;
 
-    mutex_lock(&boost_lock);
+    spin_lock_irqsave(&boost_lock, flags);
     boost_active = false;
-    mutex_unlock(&boost_lock);
+    spin_unlock_irqrestore(&boost_lock, flags);
 
     for_each_online_cpu(cpu) {
         struct cpufreq_policy *policy = cpufreq_cpu_get(cpu);
@@ -134,9 +166,12 @@ static void do_boost_off(struct work_struct *work)
                                         policy->cpuinfo.min_freq);
             }
 
-            /* Restore schedutil rate_limit_us */
-            if (sg_policy && sg_policy->tunables)
+            /* Restore schedutil rate_limit_us AND freq_update_delay_ns */
+            if (sg_policy && sg_policy->tunables) {
                 sg_policy->tunables->rate_limit_us = saved_rate_limit_us[cpu];
+                WRITE_ONCE(sg_policy->freq_update_delay_ns,
+                           (s64)saved_rate_limit_us[cpu] * NSEC_PER_USEC);
+            }
         }
 
         cpufreq_cpu_put(policy);
@@ -170,22 +205,37 @@ static void yamada_input_event(struct input_handle *handle,
                                 unsigned int code,
                                 int value)
 {
+    unsigned long flags;
+    bool need_boost_on = false;
+
     if (type != EV_ABS && type != EV_KEY)
         return;
 
-    mutex_lock(&boost_lock);
+    spin_lock_irqsave(&boost_lock, flags);
 
     if (!boost_active) {
         boost_active = true;
+        need_boost_on = true;
+    }
+
+    spin_unlock_irqrestore(&boost_lock, flags);
+
+    /*
+     * Schedule do_boost_on in process context so it can safely call
+     * freq_qos_add/update_request() which may sleep internally.
+     * mod_delayed_work with delay=0 queues it immediately.
+     *
+     * Also reset the off-timer on every event so the boost window
+     * extends from the last touch — but only reschedule if already
+     * boosting to avoid redundant timer resets on every EV_ABS flood.
+     */
+    if (need_boost_on) {
         do_boost_on();
         pr_debug("yamada_gaming_boost: boost on\n");
     }
 
-    /* Reset the off timer on every input event */
     mod_delayed_work(system_wq, &boost_off_work,
                      msecs_to_jiffies(boost_duration_ms));
-
-    mutex_unlock(&boost_lock);
 }
 
 static int yamada_input_connect(struct input_handler *handler,
@@ -277,6 +327,13 @@ static int __init yamada_gaming_boost_init(void)
 static void __exit yamada_gaming_boost_exit(void)
 {
     input_unregister_handler(&yamada_input_handler);
+
+    /*
+     * cancel_delayed_work_sync ensures the off-work has either
+     * completed or been cancelled before we proceed to cleanup.
+     * If boost is still active, run do_boost_off manually to restore
+     * all frequencies before tearing down QoS requests.
+     */
     cancel_delayed_work_sync(&boost_off_work);
 
     if (boost_active)


### PR DESCRIPTION
Fix:
1. Mutex in softirq context → potential deadlock/lockup
2. saved_rate_limit_us[] indexed by every sibling CPU, not by policy CPU
4. mod_delayed_work called on every EV_ABS flood even mid-boost